### PR TITLE
fix: support detecting touchstart event outside

### DIFF
--- a/src/useDetectClickOutside.tsx
+++ b/src/useDetectClickOutside.tsx
@@ -1,59 +1,86 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 interface Props {
   onTriggered: (e: Event) => void;
   disableClick?: boolean;
+  disableTouch?: boolean;
   disableKeys?: boolean;
   allowAnyKey?: boolean;
   triggerKeys?: string[];
 }
 
+type EventConfigItem = [boolean | undefined, string, (e: Event) => void];
+
 /**
- * Hook used to detect clicks outside a component (or an escape key press). onTriggered function is triggered on `click` or escape `keyup` event.
+ * Hook used to detect clicks outside a component (or an escape key press). onTriggered function is triggered on `click`, `touch` or escape `keyup` event.
  *
  */
 export function useDetectClickOutside({
   onTriggered,
   disableClick,
+  disableTouch,
   disableKeys,
   allowAnyKey,
   triggerKeys,
 }: Props) {
   const ref = useRef(null);
 
-  const keyListener = useCallback((e: KeyboardEvent) => {
-    if (allowAnyKey) {
-      onTriggered(e);
-    } else if (triggerKeys) {
-      if (triggerKeys.includes(e.key)) {
+  const keyListener = useCallback(
+    (e: KeyboardEvent) => {
+      if (allowAnyKey) {
         onTriggered(e);
+      } else if (triggerKeys) {
+        if (triggerKeys.includes(e.key)) {
+          onTriggered(e);
+        }
+      } else {
+        if (e.key === 'Escape') {
+          onTriggered(e);
+        }
       }
-    } else {
-      if (e.key === 'Escape') {
-        onTriggered(e);
-      }
-    }
-  }, []);
+    },
+    [allowAnyKey, triggerKeys, onTriggered]
+  );
 
-  const clickListener = useCallback(
-    (e: MouseEvent) => {
+  const clickOrTouchListener = useCallback(
+    (e: MouseEvent | TouchEvent) => {
       if (ref && ref.current) {
         if (!(ref.current! as any).contains(e.target)) {
           onTriggered?.(e);
         }
       }
     },
-    [ref.current]
+    [ref.current, onTriggered]
+  );
+
+  const eventsConfig: EventConfigItem[] = useMemo(
+    () => [
+      [disableClick, 'click', clickOrTouchListener],
+      [disableTouch, 'touchstart', clickOrTouchListener],
+      [disableKeys, 'keyup', keyListener],
+    ],
+    [disableClick, disableTouch, disableKeys, clickOrTouchListener, keyListener]
   );
 
   useEffect(() => {
-    !disableClick && document.addEventListener('click', clickListener);
-    !disableKeys && document.addEventListener('keyup', keyListener);
+    eventsConfig.map((eventConfigItem) => {
+      const [isDisabled, eventName, listener] = eventConfigItem;
+
+      if (!isDisabled) {
+        document.addEventListener(eventName, listener);
+      }
+    });
+
     return () => {
-      !disableClick && document.removeEventListener('click', clickListener);
-      !disableKeys && document.removeEventListener('keyup', keyListener);
+      eventsConfig.map((eventConfigItem) => {
+        const [isDisabled, eventName, listener] = eventConfigItem;
+
+        if (!isDisabled) {
+          document.removeEventListener(eventName, listener);
+        }
+      });
     };
-  }, []);
+  }, [eventsConfig]);
 
   return ref;
 }

--- a/tests/TestApp.tsx
+++ b/tests/TestApp.tsx
@@ -3,6 +3,7 @@ import { useDetectClickOutside } from '../src/';
 
 interface ContainerProps {
   disableClick?: boolean;
+  disableTouch?: boolean;
   disableKeys?: boolean;
   triggerKeys?: string[];
   allowAnyKey?: boolean;
@@ -14,6 +15,7 @@ interface ToggleProps extends ContainerProps {
 const ToggleableDiv: React.FC<ToggleProps> = ({
   onTriggered,
   disableClick,
+  disableTouch,
   disableKeys,
   triggerKeys,
   allowAnyKey,
@@ -21,6 +23,7 @@ const ToggleableDiv: React.FC<ToggleProps> = ({
   const ref = useDetectClickOutside({
     onTriggered,
     disableKeys,
+    disableTouch,
     disableClick,
     triggerKeys,
     allowAnyKey,
@@ -34,6 +37,7 @@ const ToggleableDiv: React.FC<ToggleProps> = ({
 
 const Container: React.FC<ContainerProps> = ({
   disableClick,
+  disableTouch,
   disableKeys,
   triggerKeys,
   allowAnyKey,
@@ -55,6 +59,7 @@ const Container: React.FC<ContainerProps> = ({
         {displayComponent && (
           <ToggleableDiv
             onTriggered={handleClose}
+            disableTouch={disableTouch}
             disableClick={disableClick}
             disableKeys={disableKeys}
             triggerKeys={triggerKeys}

--- a/tests/basicFunctionality.test.tsx
+++ b/tests/basicFunctionality.test.tsx
@@ -45,6 +45,29 @@ describe('basic functionality', () => {
       expect(queryByTestId('toggle-component')).not.toBeInTheDocument();
     });
   });
+  it('toggles the component on and off when the dummy is touched after button click', async () => {
+    const { getByTestId, queryByTestId } = wrapper();
+
+    fireEvent(
+      getByTestId('clickable-button'),
+      new MouseEvent('click', {
+        bubbles: true,
+      })
+    );
+    await waitFor(() => {
+      expect(getByTestId('toggle-component')).toBeInTheDocument();
+    });
+
+    fireEvent(
+      getByTestId('dummy'),
+      new TouchEvent('touchstart', {
+        bubbles: true,
+      })
+    );
+    await waitFor(() => {
+      expect(queryByTestId('toggle-component')).not.toBeInTheDocument();
+    });
+  });
   it('toggles child component off screen when dummy div is clicked', async () => {
     const { getByTestId, queryByTestId } = wrapper();
 

--- a/tests/touchstartDisabled.test.tsx
+++ b/tests/touchstartDisabled.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import Container from './TestApp';
+
+function wrapper() {
+  return render(<Container disableTouch />);
+}
+
+describe('touchstart disabled', () => {
+  it('does not toggle child component off screen when dummy div is touched', async () => {
+    const { getByTestId } = wrapper();
+
+    fireEvent(
+      getByTestId('clickable-button'),
+      new MouseEvent('click', {
+        bubbles: true,
+      })
+    );
+    await waitFor(() => {
+      expect(getByTestId('toggle-component')).toBeInTheDocument();
+    });
+
+    fireEvent(
+      getByTestId('dummy'),
+      new TouchEvent('touchstart', {
+        bubbles: true,
+      })
+    );
+    await waitFor(() => {
+      expect(getByTestId('toggle-component')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Hey, @zhaluza I faced one issue while using your package. When I subscribe to click outside of my element, it cannot trigger when I use swiper or another carousel component on touch devices. 

So I decided to contribute to this repository and prepared PR. Also, I prepared some refactoring for future possible wanted events to track outside of the element. And, of course, updated tests.

Hope this is a good solution. 