### PR TITLE
Allow react 17 parallel to react 16 and 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "typescript": "^4.0.5"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^18",
-    "react-dom": "^16.8.0 || ^18"
+    "react": "^16.8.0 || ^17 || ^18",
+    "react-dom": "^16.8.0 || ^17 || ^18"
   },
   "files": [
     "dist"


### PR DESCRIPTION
After i tested the new release with the react 18 peer dependencies i was not able to install them  on react 17. 
We need to specify react 17 as well.